### PR TITLE
Fix loging in and registering

### DIFF
--- a/app/common/has_errors.rb
+++ b/app/common/has_errors.rb
@@ -18,12 +18,4 @@ module HasErrors
   def errors_for(attribute)
     Errors.new(messages: errors.full_messages_for(attribute))
   end
-
-  def validations_passed?
-    errors.blank?
-  end
-
-  def validations_failed?
-    errors.any?
-  end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,12 +2,6 @@
 import "@hotwired/turbo-rails"
 import Alpine from "alpinejs"
 import * as Routes from "routes"
-import tippy from 'tippy.js'
-import "./othertest.js"
-
-tippy('#tippy', {
-    content: 'My tooltip!'
-});
 
 Alpine.data("notificationController", (initialNotices = []) => ({
     notices: [],

--- a/app/javascript/othertest.js
+++ b/app/javascript/othertest.js
@@ -1,1 +1,0 @@
-console.log("hi")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
       get "/login", to: "login#view"
       post "/login", to: "login#submit"
 
-      get "/register", to: "register#handle"
-      post "/register", to: "register_submit#handle"
+      get "/register", to: "register#view"
+      post "/register", to: "register#submit"
       delete "/logout", to: "logout#handle"
     end
   end


### PR DESCRIPTION
I've gotten rid of the validations_passed? and validations_failed? methods.

They catch errors when I manually add them by calling an ensures_x type method, but don't contain railsy validators which are invoked when calling .valid?. 

I can get around the security issue by putting the user presence check validation last and only running it if there are no errors. It feels more fragile but is fine for now.