### PR TITLE
Fix up standardrb crimes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-
 source "https://rubygems.org"
 ruby "3.3.0"
 

--- a/app/features/authentication/pages/register_controller.rb
+++ b/app/features/authentication/pages/register_controller.rb
@@ -9,7 +9,7 @@ class Authentication::Pages::RegisterController < ApplicationController
 
     attr_accessor :email, :password, :confirm_password
 
-    validates :email, presence: true, email_format: { message: "formatted incorrectly" }
+    validates :email, presence: true, email_format: {message: "formatted incorrectly"}
     validates :password, presence: true, length: {minimum: 8, maximum: 64}
     validates :confirm_password, presence: true
     validate :ensure_confirm_password_equals_password

--- a/db/migrate/20240129195221_add_key_hash_and_byte_size_to_solid_cache_entries.solid_cache.rb
+++ b/db/migrate/20240129195221_add_key_hash_and_byte_size_to_solid_cache_entries.solid_cache.rb
@@ -1,8 +1,8 @@
 # This migration comes from solid_cache (originally 20240108155507)
 class AddKeyHashAndByteSizeToSolidCacheEntries < ActiveRecord::Migration[7.1]
   def change
-    change_table :solid_cache_entries do |t|
-      t.column :key_hash,  :integer, null: true, limit: 8
+    change_table :solid_cache_entries do |t| # standard:disable Rails/BulkChangeTable
+      t.column :key_hash, :integer, null: true, limit: 8
       t.column :byte_size, :integer, null: true, limit: 4
     end
   end

--- a/db/migrate/20240129195222_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.solid_cache.rb
+++ b/db/migrate/20240129195222_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.solid_cache.rb
@@ -4,9 +4,9 @@ class AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries < Active
     change_table :solid_cache_entries, bulk: true do |t|
       t.change_null :key_hash, false
       t.change_null :byte_size, false
-      t.index  :key_hash, unique: true
-      t.index  [:key_hash, :byte_size]
-      t.index  :byte_size
+      t.index :key_hash, unique: true
+      t.index [:key_hash, :byte_size]
+      t.index :byte_size
     end
   end
 end


### PR DESCRIPTION
For `db/migrate/20240129195221_add_key_hash_and_byte_size_to_solid_cache_entries.solid_cache.rb` This is a solid cache crime that really isn't worth changing at all